### PR TITLE
[transmission] Add support for additional volumes and mounts

### DIFF
--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: transmission
 description: Transmission bittorrent client Helm Chart
 type: application
-version: 1.5.0
+version: 1.6.0
 appVersion: "1.5.0"
 dependencies:
   - name: common
@@ -12,3 +12,9 @@ maintainers:
   - name: RyuunosukeDS3
     email: camelimsaturado@outlook.com
     url: https://github.com/ryuunosukeds3
+
+annotations:
+  # Supported kind: added, changed, deprecated, removed, fixed and security
+  artifacthub.io/changes: |
+    - kind: added
+      description: "Added support for additional volumes and volume mounts"

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: transmission
 description: Transmission bittorrent client Helm Chart
 type: application
-version: 1.6.1
+version: 1.6.0
 appVersion: "4.0.6"
 
 dependencies:

--- a/charts/transmission/templates/deployment.yaml
+++ b/charts/transmission/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
               - key: update_settings.py
                 path: update_settings.py
         {{- if .Values.extraVolumes }}
-{{ toYaml .Values.extraVolumes | indent 8 }}
+        {{ toYaml .Values.extraVolumes | nindent 8 }}
         {{- end }}
 
       initContainers:
@@ -80,7 +80,7 @@ spec:
             - name: env-var-volume
               mountPath: /env-vars
             {{- if .Values.extraVolumeMounts }}
-{{ toYaml .Values.extraVolumeMounts | indent 12}}
+            {{ toYaml .Values.extraVolumeMounts | nindent 12}}
             {{ end }}
       containers:
         - name: transmission
@@ -96,7 +96,7 @@ spec:
             - name: env-var-volume
               mountPath: /env-vars
             {{- if .Values.extraVolumeMounts }}
-{{ toYaml .Values.extraVolumeMounts | indent 12}}
+            {{ toYaml .Values.extraVolumeMounts | nindent 12}}
             {{- end }}
           env:
             {{- if .Values.auth.enabled }}

--- a/charts/transmission/templates/deployment.yaml
+++ b/charts/transmission/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
             items:
               - key: update_settings.py
                 path: update_settings.py
+        {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+        {{- end }}
 
       initContainers:
         - name: update-settings
@@ -76,6 +79,9 @@ spec:
               mountPath: /config
             - name: env-var-volume
               mountPath: /env-vars
+            {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12}}
+            {{ end }}
       containers:
         - name: transmission
           image: {{ .Values.image }}
@@ -88,6 +94,9 @@ spec:
               mountPath: /config
             - name: env-var-volume
               mountPath: /env-vars
+            {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 12}}
+            {{- end }}
           env:
             {{- if .Values.auth.enabled }}
             - name: "FILE__USER"

--- a/charts/transmission/values.yaml
+++ b/charts/transmission/values.yaml
@@ -81,3 +81,20 @@ auth:
   # existingSecretName: "existing-auth-secret"
   user: username
   password: secret-pass
+
+# Define additional volume mounts
+extraVolumeMounts: []
+#  - mountPath: /mnt/content
+#    name: my-smb-share
+#    readOnly: false
+
+# Define additional volumes
+extraVolumes: []
+#  - name: my-smb-share
+#    csi:
+#      driver: smb.csi.k8s.io
+#      volumeAttributes:
+#        mountOptions: dir_mode=0777,file_mode=0777,cache=strict,actimeo=30,uid=1000,gid=9999
+#        secretName: smbcreds
+#        source: //172.16.0.234/myshare
+


### PR DESCRIPTION
This way one can mount additional volumes and mounts, such as a SMB share as shown in the values.yaml example