### PR TITLE
Define peer-* ports for traffic to work properly

### DIFF
--- a/charts/transmission/templates/deployment.yaml
+++ b/charts/transmission/templates/deployment.yaml
@@ -113,3 +113,9 @@ spec:
             - name: http
               containerPort: {{ .Values.containerPorts.http }}
               protocol: TCP
+            - name: peer-tcp
+              containerPort: {{ .Values.containerPorts.peer }}
+              protocol: TCP
+            - name: peer-udp
+              containerPort: {{ .Values.containerPorts.peer }}
+              protocol: UDP


### PR DESCRIPTION
Currently the peer-tcp and peer-udp ports do not properly work as the container has no defined ports for them. This PR adds the definitions and now it's available. An example:
```
# before this change, http port working, peer port not
$ nc -zv 172.16.255.133 9091  
Connection to 172.16.255.133 port 9091 [tcp/xmltec-xmlmail] succeeded!
$ nc -zv 172.16.255.133 51413 
nc: connectx to 172.16.255.133 port 51413 (tcp) failed: Connection refused
# After adding this change
$ nc -zv 172.16.255.133 51413 
Connection to 172.16.255.133 port 51413 [tcp/*] succeeded!
```

Edit:
This also fixes "dead torrents", partial downloads but not full. Nice :D 